### PR TITLE
Fixed JSON Serialisation Error

### DIFF
--- a/Struct.go
+++ b/Struct.go
@@ -17,7 +17,7 @@ type ResultList struct {
 // TrackData Json struct for getting the returned json data
 type TrackData struct {
 	ID           json.Number `json:"SNG_ID"`
-	MD5Origin    json.Number `json:"MD5_ORIGIN"`
+	MD5Origin    string      `json:"MD5_ORIGIN"`
 	FileSize320  json.Number `json:"FILESIZE_MP3_320"`
 	FileSize256  json.Number `json:"FILESIZE_MP3_256"`
 	FileSize128  json.Number `json:"FILESIZE_MP3_128"`

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func GetUrlDownload(id string, client *http.Client) (string, string, *http.Clien
 		format = "8"
 	}
 	songID := jsonTrack.Results.DATA.ID.String()
-	md5Origin := jsonTrack.Results.DATA.MD5Origin.String()
+	md5Origin := jsonTrack.Results.DATA.MD5Origin
 	mediaVersion := jsonTrack.Results.DATA.MediaVersion.String()
 	songTitle := jsonTrack.Results.DATA.SngTitle
 	artName := jsonTrack.Results.DATA.ArtName


### PR DESCRIPTION
Patch to fixed a JSON Serialisation Error.
```
2020/05/14 16:11:51 Error during GetUrlDownload Unmarshalling: json: invalid number literal, trying to unmarshal "\"9c505e40bb1709ba33095060XXXXX\"" into Number
```